### PR TITLE
Add translatioin file reference to Qt file

### DIFF
--- a/src/qt/bitcoin.qrc
+++ b/src/qt/bitcoin.qrc
@@ -92,5 +92,6 @@
     <qresource prefix="/translations">
         <file alias="en">locale/bitcoin_en.ts</file>
         <file alias="ru">locale/bitcoin_ru.ts</file>
+	<file alias="ptbr">locale/bitcoin_ptBR.ts</file>
     </qresource>
 </RCC>

--- a/src/qt/bitcoin.qrc
+++ b/src/qt/bitcoin.qrc
@@ -92,6 +92,6 @@
     <qresource prefix="/translations">
         <file alias="en">locale/bitcoin_en.ts</file>
         <file alias="ru">locale/bitcoin_ru.ts</file>
-        <file alias="ptbr">locale/bitcoin_ptBR.ts</file>
+        <file alias="pt-BR">locale/bitcoin_ptBR.ts</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
It's necessary to reference the translation file on `bitcoin.qrc` in order to make Qt recognize the new translation.